### PR TITLE
- Updated the minimum deployment target to iOS 14.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.1.0
+
+**Breaking Changes:**
+
+* Minimum iOS deployment target updated to 14.0 for improved performance and stability
+    * Updated the minimum deployment target to iOS 14.0
+    * Replaced the `IQKeyboardManagerSwift` pod with `IQKeyboardToolbarManager`
+    * Replaced the `ZLImageEditor` pod with `LWPhotoEditor`
+    * Upgraded dependencies and improvements
+
 ## 0.0.5
 
 * Dependency upgrade and pro-guard issue fix

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,6 +1,6 @@
 
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/appsonair_flutter_appremark.podspec
+++ b/ios/appsonair_flutter_appremark.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'appsonair_flutter_appremark'
-  s.version          = '0.0.5'
+  s.version          = '0.1.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -15,9 +15,9 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '14.0'
 
-  s.dependency 'AppsOnAir-AppRemark',  '~> 0.3.0'
+  s.dependency 'AppsOnAir-AppRemark',  '~> 1.0.1'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsonair_flutter_appremark
 description: AppsOnAir AppRemark flutter sdk allows you to capture current screen on device shake directly through AppsOnAir.
-version: 0.0.5
+version: 0.1.0
 
 #homepage:
 repository: https://github.com/apps-on-air/AppsOnAir-flutter-AppRemark


### PR DESCRIPTION
- Replaced the `IQKeyboardManagerSwift` pod with `IQKeyboardToolbarManager`
- Replaced the `ZLImageEditor` pod with `LWPhotoEditor`
- Upgraded dependencies and improvements and version bumped to 0.1.0